### PR TITLE
Update training parameters for neural network: increase set size to 5000 and max epochs to 15 ... and 14 more commits

### DIFF
--- a/NeuralNetwork/Program.cs
+++ b/NeuralNetwork/Program.cs
@@ -20,8 +20,8 @@ namespace NeuralNetwork
             string json = File.ReadAllText(stateFilePath);
             cls.FromJson(json);
             
-            string setSize = "1000";
-            int maxEpochs = 10;
+            string setSize = "5000";
+            int maxEpochs = 15;
             int bestScore = 0;
             int epochs = 0;
             stopWatch.Start();
@@ -33,7 +33,7 @@ namespace NeuralNetwork
                 Console.WriteLine($"- Training network (set {setSize}) - epoch {epochs + 1}...");
                 TrainFromFile(trainCls, @$"C:\Development\NeuralNetwork\mnist_sets\mnist_train_{setSize}.csv");
 
-                Console.WriteLine($"  Testing network (10000 testcases...");
+                Console.WriteLine($"  Testing network (10000 testcases...)");
                 
                 // Test the network with the test set, show the results per line if you want (true)
                 int score = TestFromFile(trainCls, @"C:\Development\NeuralNetwork\mnist_sets\mnist_test.csv", false);


### PR DESCRIPTION
## ✅ Changes Made:<br />- [86cd306] Update training parameters for neural network: increase set size to 5000 and max epochs to 15<br />- [c85a4c6] Merge pull request #2 from basvandesande/feature/improve<br />- [327a62c] imrpoved code<br />- [89d0d66] Create codeql.yml<br />- [a89baae] Update README.md<br />- [3410596] Update README.md<br />- [d0a4060] Update README.md<br />- [f569d6a] Merge pull request #1 from basvandesande/feature/init<br />- [f569d6a] wrote the README.md<br />- [cc6fd38] fixed serialization/deserialization. fixed paths<br />- [55d50b1] initial files<br />- [0e34ad1] Update README.md<br />- [1a494c2] Update README.md<br />- [8144d21] Update README.md<br />- [e61ed15] Initial commit<br />